### PR TITLE
WFI: Reacquire control of the core in the debugger after it executes a WFI instruction

### DIFF
--- a/src/iss/arch_if.h
+++ b/src/iss/arch_if.h
@@ -211,6 +211,11 @@ public:
 
     using unknown_instr_cb_t = std::tuple<bool, uint64_t>(arch_if* core, uint64_t addr, size_t len, uint8_t const*);
 
+    /**
+     * @brief trigger gdb stop event to resume fetch instruction thread
+     */
+    virtual void cancel_wait() {}
+
 protected:
     using rd_func_sig = iss::status(const addr_t&, unsigned, uint8_t*);
     util::delegate<rd_func_sig> rd_func;

--- a/src/iss/debugger/cmdhandler.cpp
+++ b/src/iss/debugger/cmdhandler.cpp
@@ -121,6 +121,12 @@ std::string cmd_handler::threads(std::string const& in_buf) {
     }
 }
 
+int cmd_handler::send_stop_event(){
+    CLOG(TRACE, connection) << "executing " << __FUNCTION__;
+    int ret = t->trigger_debugger_stop_event();
+    return ret;
+}
+
 std::string cmd_handler::read_registers(std::string const& in_buf) {
     CLOG(TRACE, connection) << "executing " << __FUNCTION__;
     int ret;

--- a/src/iss/debugger/cmdhandler.h
+++ b/src/iss/debugger/cmdhandler.h
@@ -111,6 +111,7 @@ public:
     std::string detach(std::string const& in_buf);
     std::string query(std::string const& in_buf);
     std::string set(std::string const& in_buf);
+    int send_stop_event();
     boost::optional<std::string> handle_extended(std::string const& in_buf);
     std::string breakpoint(std::string const& in_buf);
     int rcmd(const char* const in_buf, out_func of, data_func df);

--- a/src/iss/debugger/gdb_session.cpp
+++ b/src/iss/debugger/gdb_session.cpp
@@ -197,6 +197,7 @@ void gdb_session::receive_completed(const boost::system::error_code& e, std::str
     } else if(msg->at(0) == 3 || (msg->at(0) == -1 && msg->at(1) == -13)) {
         CLOG(TRACE, connection) << "Received BREAK, interrupting target";
         handler.t->stop();
+        handler.send_stop_event();
         respond("+");
     } else {
         CLOG(TRACE, connection) << "Received packet '" << *msg << "', processing it";

--- a/src/iss/debugger/target_adapter_if.h
+++ b/src/iss/debugger/target_adapter_if.h
@@ -158,6 +158,9 @@ public:
      avail buf is 1 */
     virtual iss::status read_registers(std::vector<uint8_t>& data_buf, std::vector<uint8_t>& avail_buf) = 0;
 
+    /* Send gdb stop event to core*/
+    virtual iss::status trigger_debugger_stop_event() = 0;
+
     /* Write all registers. buf is 4-byte aligned and it is in target
      byte order */
     virtual iss::status write_registers(const std::vector<uint8_t>& buf) = 0;


### PR DESCRIPTION
Issue: When the core executes a WFI instruction we cannot regain the core from the debugger


Fix: A new gdb_stop_evt event was added, triggered when the debugger issues a stop request. For more details, refer to this https://github.com/Minres/DBT-RISE-RISCV/pull/43 PR.

