### PR TITLE
Fix: Intermittent issue with T32 stop

### DIFF
--- a/src/iss/debugger/serialized_connection.h
+++ b/src/iss/debugger/serialized_connection.h
@@ -366,6 +366,7 @@ public:
     }
 
     void write_data(const std::string& t, boost::system::error_code& ec) {
+        std::lock_guard<std::mutex> lk(write_mtx);
         outbound_data_ = t;
 #ifdef EXTENDED_TRACE
         CLOG(TRACE) << "outbound sync data with len " << outbound_data_.size(, dbt_rise_iss) << ":'" << outbound_data_ << "'";
@@ -400,6 +401,7 @@ private:
     char inbound_buffer_[buffer_length];
     /// Holds the inbound data.
     std::vector<char> inbound_data_;
+    std::mutex write_mtx;
 
     boost::shared_ptr<async_listener> listener;
 };


### PR DESCRIPTION
The issue appears to be caused by data corruption in the GDB Remote Serial Protocol (RSP/GSP) communication.

Working scenario
<img width="521" height="180" alt="image" src="https://github.com/user-attachments/assets/ed03421b-77f7-4fcb-8b55-661d894f9417" />


Non-Working Scenario
<img width="546" height="154" alt="image" src="https://github.com/user-attachments/assets/a5dc2d16-7bdd-4375-834a-efa476deba34" />


Fix:
Protect write_data() function with a mutex to avoid concurrent writes corrupting outbound_data_ and interleaving bytes on the socket.